### PR TITLE
Env secrets

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-AWS_SQS_ACCESS_KEY_ID='AKIAUDEFLOXITAUZFQMO'
-AWS_SQS_SECRET_ACCESS_KEY='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'
-AWS_REGION='us-east-1'
-QUE_URL='https://sqs.us-east-1.amazonaws.com/281600030161/rallio-photo_liked-chute-development'
-OAUTH_TOKEN='67df6982cd69ebbb0126adfe38adb0c10c6d9460248c59bb08d2bfad20b676aa'

--- a/.env-sample
+++ b/.env-sample
@@ -1,0 +1,5 @@
+AWS_REGION='us-east-1'
+AWS_SQS_ACCESS_KEY_ID=''
+AWS_SQS_SECRET_ACCESS_KEY=''
+OAUTH_TOKEN=''
+QUE_URL='https://sqs.us-east-1.amazonaws.com/281600030161/rallio-photo_liked-chute-development'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.env
+/.node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /.env
-/.node_modules
+/node_modules

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var express = require('express');
+require('dotenv').config();
 var app = express();
 app.get('/', function (req, res) {
   res.send('Hello World!');

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "scripts": {
+    "start": "node app/index.js",
+    "env": "cp .env-sample .env"
+  },
   "dependencies": {
     "aws-sdk": "^2.544.0",
     "dotenv": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "rallio-chute",
   "version": "1.0.0",
   "main": "index.js",
-  "license": "MIT",
   "scripts": {
     "start": "node app/index.js",
     "env": "cp .env-sample .env"


### PR DESCRIPTION
We shouldn't be storing api keys and secrets in our repos, even tho they are private. So far, we've had great success with `dotenv` so that when developing we can load any sensitve info from a local `.env` file. On heroku, dotenv knows to look for the heroku env params.

* [x] removed `.env` from git tracking. added a .gitignore entry
* [x] installed `dotenv` to load hidden env files into a node context
* [x] no longer tracking `node_modules`
* [x] removed open source licensing
* [x] added "env" and "start" yarn scripts