### PR TITLE
we dont even need to globally install nodemon since vscode can use it…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Install Deps
 
 ```sh
-brew install nodemon
+yarn --global add npx
 yarn
 ```
 


### PR DESCRIPTION
… locally with a path, and we can use `npx` to refer to it if we need