### PR TITLE
a convinient sqs import so that we dont need to repeat the same AWS p…

### DIFF
--- a/app/sqs.js
+++ b/app/sqs.js
@@ -1,0 +1,23 @@
+require('dotenv').config();
+const AWS = require('aws-sdk');
+
+const apiVersion = process.env.API_VERSION;
+const endpoint = process.env.AWS_DB_URL;
+const accessKeyId = process.env.AWS_SQS_ACCESS_KEY_ID;
+const secretAccessKey = process.env.AWS_SQS_SECRET_ACCESS_KEY;
+const region = process.env.AWS_REGION;
+
+if (endpoint) {
+  AWS.config.update({ endpoint });
+}
+if (accessKeyId) {
+  AWS.config.update({ accessKeyId });
+}
+if (secretAccessKey) {
+  AWS.config.update({ secretAccessKey });
+}
+if (region) {
+  AWS.config.update({ region });
+}
+
+module.exports = new AWS.SQS({ apiVersion });


### PR DESCRIPTION
…atterns everywhere

## Usage
```js
const sqs = require('./sqs');

sqs.receiveMessage( ... )
```

We could use this and replace everywhere else we do this pattern, which is for receive, send or delete messages

```
AWS.config.update( .... )
sqs = new AWS.sqs({ apiVersion })
```